### PR TITLE
streamblocks django storage

### DIFF
--- a/wagtail_to_ion/serializers/ion/document.py
+++ b/wagtail_to_ion/serializers/ion/document.py
@@ -19,19 +19,21 @@ class IonDocumentSerializer(IonSerializer):
     def serialize(self) -> Optional[Dict[str, Any]]:
         result = super().serialize()
         result['type'] = 'filecontent'
-
-        result['mime_type'] = self.data.mime_type
         result['name'] = self.data.title
+
         try:
             result['file'] = settings.BASE_URL + self.data.file.url
             result['file_size'] = self.data.file.size
-        except FileNotFoundError as e:
+            result['checksum'] = self.data.file.checksum
+            result['mime_type'] = self.data.file.mime_type
+        except Exception as e:
             if settings.ION_ALLOW_MISSING_FILES is True:
                 result['file'] = 'FILE_MISSING'
                 result['file_size'] = 0
+                result['checksum'] = 'null:'
+                result['mime_type'] = 'application/x-empty'
             else:
                 raise e
-        result['checksum'] = self.data.checksum
 
         return result
 

--- a/wagtail_to_ion/serializers/ion/image.py
+++ b/wagtail_to_ion/serializers/ion/image.py
@@ -17,20 +17,24 @@ class IonImageSerializer(IonSerializer):
         self.data = data
         self.archive = data.archive_rendition
 
-
     def serialize(self) -> Optional[Dict[str, Any]]:
         result = super().serialize()
         result['type'] = 'imagecontent'
 
         try:
-            result['mime_type'] = self.archive.mime_type
+            result['mime_type'] = self.archive.file.mime_type
             result['image'] = settings.BASE_URL + self.archive.file.url
-            result['file_size'] = self.archive.file.file.size
+            result['file_size'] = self.archive.file.size
             result['original_image'] = settings.BASE_URL + self.data.file.url
-            result['checksum'] = self.archive.checksum
-            result['width'] = self.archive.width
-            result['height'] = self.archive.height
-        except (ValueError, AttributeError) as e:
+            result['checksum'] = self.archive.file.checksum
+            result['width'] = self.archive.file.width
+            result['height'] = self.archive.file.height
+            result['original_mime_type'] = self.data.file.mime_type
+            result['original_checksum'] = self.data.file.checksum
+            result['original_width'] = self.data.file.width
+            result['original_height'] = self.data.file.height
+            result['original_file_size'] = self.data.file.size
+        except Exception as e:
             if settings.ION_ALLOW_MISSING_FILES is True:
                 result['mime_type'] = 'application/x-empty'
                 result['image'] = 'IMAGE_MISSING'
@@ -39,14 +43,14 @@ class IonImageSerializer(IonSerializer):
                 result['checksum'] = 'null:'
                 result['width'] = 0
                 result['height'] = 0
+                result['original_mime_type'] = 'application/x-empty'
+                result['original_checksum'] = 'null:'
+                result['original_width'] = 0
+                result['original_height'] = 0
+                result['original_file_size'] = 0
             else:
                 raise e
 
-        result['original_mime_type'] = self.data.mime_type
-        result['original_checksum'] = self.data.checksum
-        result['original_width'] = self.data.width
-        result['original_height'] = self.data.height
-        result['original_file_size'] = self.data.get_file_size()
         result['translation_x'] = 0
         result['translation_y'] = 0
         result['scale'] = 1.0

--- a/wagtail_to_ion/serializers/ion/media.py
+++ b/wagtail_to_ion/serializers/ion/media.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import List, Any, Union, Dict, Optional
-import os
 
 from wagtail_to_ion.conf import settings
 from wagtail_to_ion.models.file_based_models import AbstractIonMedia
@@ -126,7 +125,7 @@ class IonMediaSerializer(IonSerializer):
     def serialize(self) -> Optional[Dict[str, Any]]:
         container = IonContainerSerializer('mediacontainer_' + self.name, subtype='media')
 
-        if os.path.exists(self.data.file.path):
+        if self.data.file.storage.exists(self.data.file.name):
             if self.data.type == 'audio':
                 container.children.append(IonAudioSerializer('audio', self.data))
             else:


### PR DESCRIPTION
Ports the file handling via storage backend to the new serializers (works only in combination with the changes from #25)

Re #15, Re #24